### PR TITLE
Fix container injection in ManagerRegistry

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,6 +8,7 @@ services:
 
     Williarin\WordpressInteropBundle\Bridge\ManagerRegistry:
         arguments:
+            $container: '@service_container'
             $managers: '%wordpress_interop.entity_managers%'
             $defaultManager: '%wordpress_interop.default_entity_manager%'
 


### PR DESCRIPTION
Symfony deprecated autowiring of ContainerInterface, so this PR fixes this by injecting it manually.