### PR TITLE
Fix missing return type deprecation

### DIFF
--- a/src/DependencyInjection/Compiler/RepositoryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/RepositoryCompilerPass.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 final class RepositoryCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $repositories = $container->findTaggedServiceIds('wordpress_interop.repository');
 


### PR DESCRIPTION
Fix this deprecation:

`Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Williarin\WordpressInteropBundle\DependencyInjection\Compiler\RepositoryCompilerPass" now to avoid errors or add an explicit @return annotation to suppress this message.`