### PR TITLE
fix: remove deprecations

### DIFF
--- a/src/Bridge/EntityManagerFactory.php
+++ b/src/Bridge/EntityManagerFactory.php
@@ -15,7 +15,7 @@ final class EntityManagerFactory
         Connection $connection,
         SerializerInterface $serializer,
         string $tablePrefix = 'wp_',
-        DuplicationServiceInterface $duplicationService = null,
+        ?DuplicationServiceInterface $duplicationService = null,
     ): EntityManagerInterface {
         return new EntityManager($connection, $serializer, $tablePrefix, $duplicationService);
     }


### PR DESCRIPTION
I getting some deprecation (PHP 8.4.5):

`Implicitly marking parameter $duplicationService as nullable is deprecated, the explicit nullable type must be used instead`

Please check it when you have time.